### PR TITLE
Upgrade target framework from .NET 8.0 to .NET 10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ project.lock.json
 
 *.dll
 
+# Benchmark artifacts
+BenchmarkDotNet.Artifacts/

--- a/src/ZChain.ConsoleApp/ZChain.ConsoleApp.csproj
+++ b/src/ZChain.ConsoleApp/ZChain.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ZChain.ConsoleApp/ZChain.ConsoleApp.csproj
+++ b/src/ZChain.ConsoleApp/ZChain.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ZChain.Core/ZChain.Core.csproj
+++ b/src/ZChain.Core/ZChain.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/src/ZChain.Core/ZChain.Core.csproj
+++ b/src/ZChain.Core/ZChain.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/src/ZChain.CpuMiner/ZChain.CpuMiner.csproj
+++ b/src/ZChain.CpuMiner/ZChain.CpuMiner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ZChain.CpuMiner/ZChain.CpuMiner.csproj
+++ b/src/ZChain.CpuMiner/ZChain.CpuMiner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ZChain.Hashers/ZChain.Hashers.csproj
+++ b/src/ZChain.Hashers/ZChain.Hashers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/ZChain.Hashers/ZChain.Hashers.csproj
+++ b/src/ZChain.Hashers/ZChain.Hashers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/ZChain.PerformanceTesting/ZChain.PerformanceTesting.csproj
+++ b/src/ZChain.PerformanceTesting/ZChain.PerformanceTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ZChain.PerformanceTesting/ZChain.PerformanceTesting.csproj
+++ b/src/ZChain.PerformanceTesting/ZChain.PerformanceTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ZChain.Tests/ZChain.Tests.csproj
+++ b/src/ZChain.Tests/ZChain.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/ZChain.Tests/ZChain.Tests.csproj
+++ b/src/ZChain.Tests/ZChain.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Upgrade all projects from `net8.0` to `net9.0`
- Add `BenchmarkDotNet.Artifacts/` to `.gitignore`

## Test plan
- [x] All unit tests pass (`dotnet test`)
- [x] Performance benchmarks run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded all projects in the repository to target .NET 10.0.
  * Updated version control ignore patterns to exclude benchmark artifacts.
  * Applied target-framework updates across application, library, test, miner and performance projects with no public API or behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->