### PR TITLE
Update NuGet packages to latest versions

### DIFF
--- a/src/ZChain.Core/ZChain.Core.csproj
+++ b/src/ZChain.Core/ZChain.Core.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/ZChain.Tests/ZChain.Tests.csproj
+++ b/src/ZChain.Tests/ZChain.Tests.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
Updated all NuGet packages to their latest stable versions while maintaining BenchmarkDotNet at 0.14.0 for measurement stability.

## Package Updates
- Newtonsoft.Json: 13.0.3 → 13.0.4
- Microsoft.NET.Test.Sdk: 17.11.1 → 18.0.1
- Shouldly: 4.2.1 → 4.3.0
- xunit: 2.9.2 → 2.9.3
- xunit.runner.visualstudio: 2.8.2 → 3.1.5
- BenchmarkDotNet: kept at 0.14.0

## Testing
- ✅ All unit tests pass (10/10)
- ✅ Benchmarks run successfully
- ✅ Build completes without warnings

## Notes
BenchmarkDotNet was tested at version 0.15.8 but showed high variance (5-34%) across multiple runs compared to 0.14.0 (1-21% variance). Kept at 0.14.0 for consistent, reliable performance measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to latest versions for improved stability and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->