### PR TITLE
Remove deprecated dotnet-xunit CLI tool reference

### DIFF
--- a/src/ZChain.Tests/ZChain.Tests.csproj
+++ b/src/ZChain.Tests/ZChain.Tests.csproj
@@ -22,7 +22,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Removed `<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />`

`DotNetCliToolReference` is legacy and not supported in .NET 5+ SDK-style projects. The modern test workflow uses `xunit.runner.visualstudio` with `Microsoft.NET.Test.Sdk` for test discovery and execution.

## Test plan
- [x] `dotnet test` - 10/10 tests pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration for test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->